### PR TITLE
Fix message about where revdep check results are saved

### DIFF
--- a/R/revdep.R
+++ b/R/revdep.R
@@ -232,7 +232,7 @@ revdep_check_from_cache <- function(pkg, cache) {
 
   do.call(check_cran, cache)
 
-  cat_rule("Saving check results to `revdep/check.rds`")
+  cat_rule("Saving check results to `revdep/checks.rds`")
   revdep_check_save(pkg, cache$revdeps, cache$check_dir, cache$libpath)
 
   # Delete cache and check_dir on successful run


### PR DESCRIPTION
When doing reverse-dependency checks, a message says "Saving check results to `revdep/check.rds`" (https://github.com/hadley/devtools/blob/master/R/revdep.R#L235), but the actual file name is `revdep/checks.rds` (https://github.com/hadley/devtools/blob/master/R/revdep.R#L288).